### PR TITLE
Add pynit alias for Python virtual environment activation

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -156,6 +156,7 @@ alias rmmodules="find . -name node_modules -type d -prune -exec rm -rf '{}' +"
 # Python
 alias py2="pyenv global 2"
 alias py3="pyenv global 3"
+alias pynit="source .venv/bin/activate"
 
 # System Utils
 alias rmorig="rm -rf **/*.orig"


### PR DESCRIPTION
## Summary
Added a new shell alias to streamline Python virtual environment activation in zsh.

## Changes
- Added `pynit` alias that sources the Python virtual environment activation script (`.venv/bin/activate`)
- Placed alongside existing Python-related aliases (`py2`, `py3`) for logical organization

## Details
This alias provides a convenient shorthand for activating a standard Python virtual environment, reducing the need to type the full path `source .venv/bin/activate` each time a venv needs to be activated in a project.

https://claude.ai/code/session_018BYpRMeNCTSgjUvEqdZXFt